### PR TITLE
Add hourly Bitcoin price email automation

### DIFF
--- a/.github/workflows/btc-hourly-email.yml
+++ b/.github/workflows/btc-hourly-email.yml
@@ -1,0 +1,28 @@
+name: Hourly Bitcoin Price Email
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+
+jobs:
+  send-bitcoin-price:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Fetch BTC price and send email
+        env:
+          SMTP_HOST: ${{ secrets.SMTP_HOST }}
+          SMTP_PORT: ${{ secrets.SMTP_PORT }}
+          SMTP_USER: ${{ secrets.SMTP_USER }}
+          SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
+          EMAIL_FROM: ${{ secrets.EMAIL_FROM }}
+          EMAIL_TO: ${{ secrets.EMAIL_TO }}
+        run: python scripts/btc_price_email.py

--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # hello-tron
-Sample Repository - from master branch
+
+Hourly Bitcoin price email automation via GitHub Actions.
+
+## What this does
+- Runs every hour (`0 * * * *`) and can also be run manually.
+- Fetches the current BTC price in USD from CoinGecko.
+- Sends an email with the latest Bitcoin price via your SMTP provider.
+
+## Files
+- `.github/workflows/btc-hourly-email.yml` – Hourly automation workflow.
+- `scripts/btc_price_email.py` – Script that fetches price and sends email.
+
+## Required GitHub Secrets
+Configure these repository secrets:
+- `SMTP_HOST`
+- `SMTP_PORT` (typically `587`)
+- `SMTP_USER`
+- `SMTP_PASSWORD`
+- `EMAIL_FROM`
+- `EMAIL_TO`
+
+## Notes
+- If your provider requires SSL on port `465`, update the script to use `smtplib.SMTP_SSL`.
+- CoinGecko has API limits; this workflow calls it once per hour.

--- a/scripts/btc_price_email.py
+++ b/scripts/btc_price_email.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Fetch current Bitcoin price (USD) and email it."""
+
+import json
+import os
+import smtplib
+import ssl
+import urllib.request
+from datetime import datetime, timezone
+from email.message import EmailMessage
+
+
+def get_bitcoin_price_usd() -> float:
+    url = "https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd"
+    with urllib.request.urlopen(url, timeout=15) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+    return float(payload["bitcoin"]["usd"])
+
+
+def send_email(price_usd: float) -> None:
+    smtp_host = os.environ["SMTP_HOST"]
+    smtp_port = int(os.environ.get("SMTP_PORT", "587"))
+    smtp_user = os.environ["SMTP_USER"]
+    smtp_password = os.environ["SMTP_PASSWORD"]
+    email_from = os.environ["EMAIL_FROM"]
+    email_to = os.environ["EMAIL_TO"]
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    subject = f"Bitcoin price update: ${price_usd:,.2f}"
+    body = (
+        "Hourly Bitcoin Price Alert\n\n"
+        f"Current BTC price: ${price_usd:,.2f} USD\n"
+        f"Checked at: {timestamp}\n"
+    )
+
+    message = EmailMessage()
+    message["Subject"] = subject
+    message["From"] = email_from
+    message["To"] = email_to
+    message.set_content(body)
+
+    context = ssl.create_default_context()
+    with smtplib.SMTP(smtp_host, smtp_port) as server:
+        server.starttls(context=context)
+        server.login(smtp_user, smtp_password)
+        server.send_message(message)
+
+
+if __name__ == "__main__":
+    btc_price = get_bitcoin_price_usd()
+    send_email(btc_price)


### PR DESCRIPTION
### Motivation
- Provide an automated hourly check of the Bitcoin price and deliver a notification email so recipients receive regular price updates.
- Allow manual runs in addition to the scheduled hourly trigger for ad-hoc checks.

### Description
- Add GitHub Actions workflow `./.github/workflows/btc-hourly-email.yml` that runs on schedule `0 * * * *` and supports manual `workflow_dispatch` trigger.
- Add `scripts/btc_price_email.py` which implements `get_bitcoin_price_usd()` (fetches BTC/USD from CoinGecko) and `send_email()` (sends via SMTP using environment-based credentials and STARTTLS).
- Use environment variables / repository secrets `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASSWORD`, `EMAIL_FROM`, and `EMAIL_TO` to configure email delivery in the workflow step that runs `python scripts/btc_price_email.py`.
- Update `README.md` with setup instructions, required secrets, and notes about SSL/port and API limits.

### Testing
- Ran `python -m py_compile scripts/btc_price_email.py`, which succeeded.
- Attempted `python scripts/btc_price_email.py`, which failed in this environment due to outbound network/proxy restrictions (error: `Tunnel connection failed: 403 Forbidden`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e3957388fc83319014f77cafece655)